### PR TITLE
Improve geocoding reliability and station lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A self-contained web app for planning semi-truck fuel routes with:
 Click **Reset** to clear inputs.
 
 ## APIs used
+- [Geoapify Geocoding API](https://apidocs.geoapify.com/) — Address lookup & autocomplete.
 - [Geoapify Routing API](https://apidocs.geoapify.com/) — Truck-aware routing.
 - [Geoapify Places API](https://apidocs.geoapify.com/) — Truck stops & fuel stations.
 - [EIA v2 Petroleum Prices API](https://www.eia.gov/opendata/) — Diesel price estimates.

--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
       const EIA_KEY='xfGagmkwAlzScExC639DPUctyuWheqZSQPfxErvu';
       function note(kind,msg){ const el=$('alerts'); el.className = 'small '+(kind==='ok'?'ok':kind==='error'?'error':'muted'); el.innerHTML=msg; }
 
-      // Autocomplete (Nominatim)
+      // Autocomplete (Geoapify)
       let suggestTimer=null;
       function attachAutocomplete(inputId,listId){
         const input=$(inputId), list=$(listId);
@@ -152,9 +152,12 @@
           if(q.length<3){ list.innerHTML=''; return; }
           suggestTimer=setTimeout(async()=>{
             try{
-              const url=`https://nominatim.openstreetmap.org/search?format=json&addressdetails=1&limit=8&q=${encodeURIComponent(q)}`;
-              const js=await fetch(url,{headers:{'Accept-Language':'en'}}).then(r=>r.json());
-              const uniq=[...new Set(js.map(r=>r.display_name))];
+              const u=new URL('https://api.geoapify.com/v1/geocode/autocomplete');
+              u.searchParams.set('text', q);
+              u.searchParams.set('limit','8');
+              u.searchParams.set('apiKey', GEOAPIFY_KEY);
+              const j=await fetch(u.toString()).then(r=>r.json());
+              const uniq=[...new Set((j.features||[]).map(f=>f.properties.formatted))];
               list.innerHTML=uniq.map(v=>`<option value="${v}"></option>`).join('');
             }catch{}
           },200);
@@ -163,10 +166,14 @@
 
       // Geocode + routing (Geoapify fallback to OSRM)
       async function geocode(q){
-        const url=`https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(q)}&limit=1`;
-        const js=await fetch(url,{headers:{'Accept-Language':'en'}}).then(r=>r.json());
-        if(!js[0]) throw new Error('Location not found: '+q);
-        return [parseFloat(js[0].lon), parseFloat(js[0].lat)];
+        const u=new URL('https://api.geoapify.com/v1/geocode/search');
+        u.searchParams.set('text', q);
+        u.searchParams.set('limit','1');
+        u.searchParams.set('apiKey', GEOAPIFY_KEY);
+        const j=await fetch(u.toString()).then(r=>r.json());
+        const f=j.features?.[0];
+        if(!f) throw new Error('Location not found: '+q);
+        return [f.geometry.coordinates[0], f.geometry.coordinates[1]];
       }
       async function routeOSRM(start,end){
         const url=`https://router.project-osrm.org/route/v1/driving/${start[0]},${start[1]};${end[0]},${end[1]}?overview=full&geometries=geojson`;
@@ -203,24 +210,47 @@
       // Places (Geoapify)
       async function fetchStationsGeoapify(geo, detourMi, chainFilter){
         const coords=geo.coordinates;
-        let minLon=Infinity,maxLon=-Infinity,minLat=Infinity,maxLat=-Infinity,sumLat=0,n=0;
-        for(const [lon,lat] of coords){ minLon=Math.min(minLon,lon); maxLon=Math.max(maxLon,lon); minLat=Math.min(minLat,lat); maxLat=Math.max(maxLat,lat); sumLat+=lat; n++; }
-        const meanLat=sumLat/n, degPerMiLat=1/69.0, degPerMiLon=1/(69.172*Math.cos(meanLat*Math.PI/180));
-        const padLon=Math.max(detourMi,5)*degPerMiLon, padLat=Math.max(detourMi,5)*degPerMiLat;
-        const bbox={minLon:minLon-padLon,minLat:minLat-padLat,maxLon:maxLon+padLon,maxLat:maxLat+padLat};
-
         const major=['Pilot','Flying J','Love\'s','TA','Petro','TA Express','Sapp Bros','Kwik Trip','Kwik Star','Maverik'];
-
-        const url=new URL('https://api.geoapify.com/v2/places');
-        url.searchParams.set('categories','service.vehicle.fuel,transport.truck_stop');
-        url.searchParams.set('filter',`rect:${bbox.minLon},${bbox.minLat},${bbox.maxLon},${bbox.maxLat}`);
-        url.searchParams.set('limit','500');
-        url.searchParams.set('apiKey',GEOAPIFY_KEY);
-        const r=await fetch(url.toString());
-        if(!r.ok) throw new Error('Places error '+r.status);
-        const j=await r.json();
-
-        let list=(j.features||[]).map(f=>({
+        // split long routes into smaller bounding boxes to avoid API 400 errors
+        function splitBoxes(cs, span=2){
+          const boxes=[]; let cur=[],minLon,maxLon,minLat,maxLat,sumLat=0;
+          for(const [lon,lat] of cs){
+            if(cur.length===0){
+              cur.push([lon,lat]);
+              minLon=maxLon=lon; minLat=maxLat=lat; sumLat=lat;
+            }else{
+              const nMinLon=Math.min(minLon,lon), nMaxLon=Math.max(maxLon,lon);
+              const nMinLat=Math.min(minLat,lat), nMaxLat=Math.max(maxLat,lat);
+              if((nMaxLon-nMinLon)>span || (nMaxLat-nMinLat)>span){
+                boxes.push({minLon,maxLon,minLat,maxLat,meanLat:sumLat/cur.length});
+                cur=[[lon,lat]];
+                minLon=maxLon=lon; minLat=maxLat=lat; sumLat=lat;
+              }else{
+                cur.push([lon,lat]);
+                minLon=nMinLon; maxLon=nMaxLon; minLat=nMinLat; maxLat=nMaxLat; sumLat+=lat;
+              }
+            }
+          }
+          if(cur.length) boxes.push({minLon,maxLon,minLat,maxLat,meanLat:sumLat/cur.length});
+          return boxes;
+        }
+        const boxes=splitBoxes(coords);
+        const feats=[];
+        for(const b of boxes){
+          const degPerMiLat=1/69.0, degPerMiLon=1/(69.172*Math.cos(b.meanLat*Math.PI/180));
+          const padLon=Math.max(detourMi,5)*degPerMiLon, padLat=Math.max(detourMi,5)*degPerMiLat;
+          const url=new URL('https://api.geoapify.com/v2/places');
+          url.searchParams.set('categories','service.vehicle.fuel,transport.truck_stop');
+          url.searchParams.set('filter',`rect:${b.minLon-padLon},${b.minLat-padLat},${b.maxLon+padLon},${b.maxLat+padLat}`);
+          url.searchParams.set('limit','500');
+          url.searchParams.set('apiKey',GEOAPIFY_KEY);
+          const r=await fetch(url.toString());
+          if(!r.ok) throw new Error('Places error '+r.status);
+          const j=await r.json();
+          feats.push(...(j.features||[]));
+        }
+        const seen=new Set();
+        let list=feats.map(f=>({
           id:f.properties.place_id || f.properties.datasource?.raw?.id || f.properties.osm_id || Math.random(),
           name:f.properties.name || 'Fuel Station',
           brand:f.properties.brand || f.properties.operator || '',
@@ -228,7 +258,7 @@
           addr:[f.properties.housenumber,f.properties.street,f.properties.city,f.properties.state].filter(Boolean).join(', '),
           state:(f.properties.state_code || f.properties.state || '').toString().toUpperCase().replace('US-',''),
           truckFriendly:true, dieselPrice:null, dieselPrice_note:null
-        }));
+        })).filter(s=>{ if(seen.has(s.id)) return false; seen.add(s.id); return true; });
         if(chainFilter==='major') list=list.filter(s=>major.some(m=>(s.brand||'').toLowerCase().includes(m.toLowerCase())));
         if(chainFilter==='independent') list=list.filter(s=>!major.some(m=>(s.brand||'').toLowerCase().includes(m.toLowerCase())));
         return list;


### PR DESCRIPTION
## Summary
- use Geoapify autocomplete and geocoding for address searches
- split long routes into smaller Geoapify Places queries to avoid 400 errors
- document geocoding API usage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68abef01f07c8331997afdf07820f219