### PR TITLE
Add React frontend scaffold and shared types

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fuel Route Planner</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "frontend",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.2",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import RouteForm from './components/RouteForm';
+import StationList from './components/StationList';
+import PlanSummary from './components/PlanSummary';
+import { Station, PlanResult, RouteFormValues } from './types';
+
+const App: React.FC = () => {
+  const [stations, setStations] = useState<Station[]>([]);
+  const [plan, setPlan] = useState<PlanResult | null>(null);
+
+  const handlePlan = (values: RouteFormValues) => {
+    console.log('Plan request', values);
+    // Integration with backend will populate stations and plan
+    setStations([]);
+    setPlan(null);
+  };
+
+  return (
+    <div className="wrap">
+      <RouteForm onPlan={handlePlan} />
+      <StationList stations={stations} />
+      <PlanSummary result={plan} />
+    </div>
+  );
+};
+
+export default App;

--- a/frontend/src/components/PlanSummary.tsx
+++ b/frontend/src/components/PlanSummary.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { PlanResult } from '../types';
+
+interface Props {
+  result: PlanResult | null;
+}
+
+const PlanSummary: React.FC<Props> = ({ result }) => (
+  <section className="card" style={{ marginTop: 12 }}>
+    <h2>Plan Summary</h2>
+    {!result ? (
+      <div className="muted">No plan calculated.</div>
+    ) : (
+      <>
+        <div className="kvs">
+          <div>Effective MPG</div>
+          <div className="mono">{result.mpgEff.toFixed(2)}</div>
+          <div>Max range (full tank)</div>
+          <div className="mono">{result.maxRange.toFixed(0)} mi</div>
+          <div>Total route</div>
+          <div className="mono">{result.totalMiles.toFixed(0)} mi</div>
+        </div>
+        <div className="list" style={{ marginTop: 8 }}>
+          {result.plan.length === 0 ? (
+            <div className="muted">No actions needed.</div>
+          ) : (
+            result.plan.map((step, i) =>
+              step.type === 'stop' ? (
+                <div className="station" key={i}>
+                  <div>
+                    <b>Stop at:</b> {step.station.name}
+                    <div>
+                      Buy <b>{step.gallons.toFixed(1)} gal</b>
+                      {step.cost != null
+                        ? ` @ ~$${step.station.dieselPrice?.toFixed(3)}/gal ≈ $${step.cost.toFixed(2)}`
+                        : ''}
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div className="station" key={i}>
+                  <div>{step.action}</div>
+                </div>
+              )
+            )
+          )}
+        </div>
+      </>
+    )}
+  </section>
+);
+
+export default PlanSummary;

--- a/frontend/src/components/RouteForm.tsx
+++ b/frontend/src/components/RouteForm.tsx
@@ -1,0 +1,163 @@
+import React, { useState, ChangeEvent, FormEvent } from 'react';
+import { RouteFormValues } from '../types';
+
+interface Props {
+  onPlan: (values: RouteFormValues) => void;
+}
+
+const RouteForm: React.FC<Props> = ({ onPlan }) => {
+  const [values, setValues] = useState<RouteFormValues>({
+    start: '',
+    end: '',
+    mpg: 8,
+    tank: 160,
+    fuelVal: 40,
+    fuelUnit: 'gal',
+    reserve: 25,
+    weight: undefined,
+    terrain: 'rolling',
+    govSpeed: 70,
+    wind: undefined,
+    driverCost: 122,
+  });
+
+  const update = (e: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value, type } = e.target;
+    setValues((v) => ({
+      ...v,
+      [name]: type === 'number' && value !== '' ? Number(value) : value,
+    }));
+  };
+
+  const submit = (e: FormEvent) => {
+    e.preventDefault();
+    onPlan(values);
+  };
+
+  return (
+    <form className="card" onSubmit={submit} style={{ marginTop: 12 }}>
+      <div className="row">
+        <label>
+          <span className="small muted">Start (exact address OK)</span>
+          <input name="start" value={values.start} onChange={update} />
+        </label>
+        <label>
+          <span className="small muted">Destination (exact address OK)</span>
+          <input name="end" value={values.end} onChange={update} />
+        </label>
+      </div>
+      <div className="row-3" style={{ marginTop: 8 }}>
+        <label>
+          <span className="small muted">Base MPG</span>
+          <input
+            name="mpg"
+            type="number"
+            step="0.1"
+            value={values.mpg}
+            onChange={update}
+          />
+        </label>
+        <label>
+          <span className="small muted">Tank size (gal)</span>
+          <input
+            name="tank"
+            type="number"
+            step="1"
+            value={values.tank}
+            onChange={update}
+          />
+        </label>
+        <label>
+          <span className="small muted">Current fuel</span>
+          <div className="row" style={{ gridTemplateColumns: '2fr 1fr' }}>
+            <input
+              name="fuelVal"
+              type="number"
+              step="0.1"
+              value={values.fuelVal}
+              onChange={update}
+            />
+            <select
+              name="fuelUnit"
+              value={values.fuelUnit}
+              onChange={update}
+            >
+              <option value="gal">gal</option>
+              <option value="pct">% of tank</option>
+            </select>
+          </div>
+        </label>
+      </div>
+      <div className="row-3" style={{ marginTop: 8 }}>
+        <label>
+          <span className="small muted">Reserve buffer (miles)</span>
+          <input
+            name="reserve"
+            type="number"
+            step="1"
+            value={values.reserve}
+            onChange={update}
+          />
+        </label>
+        <label>
+          <span className="small muted">Gross weight (lbs, optional)</span>
+          <input
+            name="weight"
+            type="number"
+            step="100"
+            value={values.weight ?? ''}
+            onChange={update}
+          />
+        </label>
+        <label>
+          <span className="small muted">Terrain</span>
+          <select name="terrain" value={values.terrain} onChange={update}>
+            <option value="flat">Flat</option>
+            <option value="rolling">Rolling</option>
+            <option value="hilly">Hilly</option>
+            <option value="mountain">Mountain</option>
+          </select>
+        </label>
+      </div>
+      <div className="row-3" style={{ marginTop: 8 }}>
+        <label>
+          <span className="small muted">Governed speed (mph)</span>
+          <input
+            name="govSpeed"
+            type="number"
+            step="1"
+            value={values.govSpeed}
+            onChange={update}
+          />
+        </label>
+        <label>
+          <span className="small muted">Headwind (mph, optional)</span>
+          <input
+            name="wind"
+            type="number"
+            step="1"
+            value={values.wind ?? ''}
+            onChange={update}
+          />
+        </label>
+        <label>
+          <span className="small muted">Driver cost ($/hr)</span>
+          <input
+            name="driverCost"
+            type="number"
+            step="1"
+            value={values.driverCost}
+            onChange={update}
+          />
+        </label>
+      </div>
+      <div style={{ marginTop: 8 }}>
+        <button type="submit" className="btn primary">
+          Plan Route
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default RouteForm;

--- a/frontend/src/components/StationList.tsx
+++ b/frontend/src/components/StationList.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Station } from '../types';
+
+interface Props {
+  stations: Station[];
+}
+
+const StationList: React.FC<Props> = ({ stations }) => (
+  <section className="card" style={{ marginTop: 12 }}>
+    <h2>Stations</h2>
+    <div className="list">
+      {stations.length === 0 ? (
+        <div className="muted">No stations loaded.</div>
+      ) : (
+        stations.map((s) => (
+          <div className="station" key={`${s.lat}-${s.lon}`}>
+            <div>
+              <b>{s.name}</b>
+              <div className="muted">{s.addr}</div>
+              <div style={{ marginTop: 4 }}>
+                Brand: <span className="badge">{s.brand ?? '—'}</span>
+              </div>
+              <div style={{ marginTop: 4 }}>
+                Diesel:{' '}
+                <b>
+                  {s.dieselPrice != null
+                    ? `$${s.dieselPrice.toFixed(3)}/gal`
+                    : '—'}
+                </b>
+              </div>
+            </div>
+            <div className="small">{s.milesFromStart.toFixed(1)} mi</div>
+          </div>
+        ))
+      )}
+    </div>
+  </section>
+);
+
+export default StationList;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,23 @@
+:root{ --bg:#0b1120; --panel:#0f172a; --muted:#94a3b8; --text:#e5e7eb; --accent:#3b82f6; --border:rgba(148,163,184,.18) }
+body{margin:0;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Arial;background:var(--bg);color:var(--text)}
+.wrap{max-width:1200px;margin:0 auto;padding:20px}
+.card{background:linear-gradient(to bottom right, rgba(15,23,42,.92), rgba(2,6,23,.92));border:1px solid var(--border);border-radius:16px;padding:14px}
+.row{display:grid;grid-template-columns:1fr 1fr;gap:10px}
+.row-3{display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px}
+.tools{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
+input,select,button{font-size:14px}
+input,select{width:100%;padding:10px 12px;border-radius:12px;border:1px solid var(--border);background:#0b1320;color:#e5e7eb}
+.btn{padding:10px 14px;border-radius:12px;border:1px solid var(--border);background:#14213a;color:#e5e7eb;cursor:pointer}
+.btn.primary{background:var(--accent);color:#fff}
+.list{display:flex;flex-direction:column;gap:10px}
+.station{display:flex;justify-content:space-between;gap:10px;padding:10px;border:1px solid var(--border);border-radius:12px;background:#0b1320}
+.badge{font-size:11px;padding:2px 8px;border-radius:999px;background:#1f2937;color:#e5e7eb;border:1px solid var(--border)}
+.small{font-size:12px}
+.muted{color:var(--muted)}
+.ok{background:#0b3320;border:1px solid #22c55e;color:#dcfce7;padding:8px;border-radius:10px}
+.error{background:#2b1515;border:1px solid #7f1d1d;color:#fecaca;padding:8px;border-radius:10px}
+.kvs{display:grid;grid-template-columns:1fr 1fr;gap:6px}
+.mono{font-variant-numeric:tabular-nums}
+.loading{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.35);z-index:9999}
+.spinner{width:36px;height:36px;border:4px solid rgba(255,255,255,.3);border-top-color:#3b82f6;border-radius:50%;animation:spin 1s linear infinite}
+@keyframes spin{to{transform:rotate(360deg)}}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,47 @@
+export interface RouteFormValues {
+  start: string;
+  end: string;
+  mpg: number;
+  tank: number;
+  fuelVal: number;
+  fuelUnit: 'gal' | 'pct';
+  reserve: number;
+  weight?: number;
+  terrain: 'flat' | 'rolling' | 'hilly' | 'mountain';
+  govSpeed: number;
+  wind?: number;
+  driverCost: number;
+}
+
+export interface Station {
+  id?: string;
+  name: string;
+  addr?: string;
+  brand?: string;
+  lat: number;
+  lon: number;
+  dieselPrice?: number;
+  dieselPrice_note?: string;
+  milesFromStart: number;
+}
+
+export interface PlanStepStop {
+  type: 'stop';
+  station: Station;
+  gallons: number;
+  cost: number | null;
+}
+
+export interface PlanStepGap {
+  type: 'gap';
+  action: string;
+}
+
+export type PlanStep = PlanStepStop | PlanStepGap;
+
+export interface PlanResult {
+  plan: PlanStep[];
+  mpgEff: number;
+  maxRange: number;
+  totalMiles: number;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React app in `frontend/`
- split UI into `RouteForm`, `StationList`, and `PlanSummary` components
- centralize shared interfaces in `src/types.ts`

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2freact)
- `npm run build` (fails: Cannot find module 'react' or its corresponding type declarations)


------
https://chatgpt.com/codex/tasks/task_b_68abf5280e248331b6d2a0b2d694ad5f