### PR TITLE
Add favorites and route history with backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 
+# Database
+data.db
+
 # Logs
 logs
 *.log

--- a/README.md
+++ b/README.md
@@ -15,18 +15,21 @@ A self-contained web app for planning semi-truck fuel routes with:
 - **EIA integration**: Attaches state-average diesel prices (fallback to PADD or U.S. national average).
 - **AI Recommendation**: Suggests optimal stops, gallons to purchase, and estimated cost savings.
 - Loading spinner overlay while planning route.
+- **Favorites & History**: Backend stores last ten routes and allows marking favorites.
 
 ## Requirements
 - A modern web browser (Chrome, Edge, Firefox, Safari).
 - No build tools or external JS required — **single HTML file**.
 - Internet connection (to call Geoapify + EIA APIs).
+- Node.js runtime for the optional backend that saves favorites/history.
 
 ## Usage
-1. Open `fuel-route-planner.html` in your browser.
-2. Enter **Start** and **Destination**.
-3. Fill in vehicle parameters.
-4. Click **Plan Route**.
-5. Review station list + AI recommendations.
+1. `npm install` and `npm start` to launch the backend server (serves `index.html`).
+2. Open `http://localhost:3000` in your browser.
+3. Enter **Start** and **Destination**.
+4. Fill in vehicle parameters.
+5. Click **Plan Route**.
+6. Review station list, route history and favorites.
 
 Click **Reset** to clear inputs.
 

--- a/index.html
+++ b/index.html
@@ -63,6 +63,16 @@
     </header>
 
     <section class="card" style="margin-top:12px">
+      <h2>Favorites</h2>
+      <div id="favorites"></div>
+    </section>
+
+    <section class="card" style="margin-top:12px">
+      <h2>Recent Routes</h2>
+      <div id="history"></div>
+    </section>
+
+    <section class="card" style="margin-top:12px">
       <div class="row">
         <label><span class="small muted">Start (exact address OK)</span>
           <input id="start" placeholder="6418 Centennial Blvd, Nashville, TN 37209" list="startList" autocomplete="off" />
@@ -404,6 +414,47 @@
         });
       }
 
+      // Favorites and History
+      async function loadStored(){
+        try{
+          const [hist, fav] = await Promise.all([
+            fetch('/api/routes').then(r=>r.json()),
+            fetch('/api/favorites').then(r=>r.json())
+          ]);
+          renderHistory(hist);
+          renderFavorites(fav);
+        }catch(e){ console.error(e); }
+      }
+      function renderHistory(items){
+        const host=$('history'); host.innerHTML='';
+        if(!items.length){ host.innerHTML='<div class="muted">No recent routes</div>'; return; }
+        items.forEach(r=>{
+          const row=document.createElement('div'); row.className='station';
+          row.innerHTML=`<div>${r.start} → ${r.end}</div><button data-id="${r.id}" class="btn small favbtn">${r.favorite?'Unfavorite':'Favorite'}</button>`;
+          host.appendChild(row);
+        });
+        host.querySelectorAll('.favbtn').forEach(btn=>{
+          btn.onclick=async()=>{
+            const id=btn.getAttribute('data-id');
+            if(btn.textContent==='Favorite'){
+              await fetch('/api/favorites',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({id})});
+            }else{
+              await fetch('/api/favorites/'+id,{method:'DELETE'});
+            }
+            await loadStored();
+          };
+        });
+      }
+      function renderFavorites(items){
+        const host=$('favorites'); host.innerHTML='';
+        if(!items.length){ host.innerHTML='<div class="muted">No favorites</div>'; return; }
+        items.forEach(r=>{
+          const row=document.createElement('div'); row.className='station';
+          row.innerHTML=`<div>${r.start} → ${r.end}</div>`;
+          host.appendChild(row);
+        });
+      }
+
       // Plan handler
       async function plan(){
         try{
@@ -426,6 +477,9 @@
           renderStations(geo, stns);
           note('ok','Route and stations loaded.');
 
+          await fetch('/api/routes',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({start:startQ,end:endQ})});
+          await loadStored();
+
           $('recoBtn').onclick=()=>{ const out=aiRecommend(geo, stns); renderPlan(out); };
         }catch(e){
           note('error', e.message);
@@ -439,6 +493,7 @@
       $('resetBtn').onclick=()=>location.reload();
       $('sortBy').onchange=plan; $('chainFilter').onchange=plan; $('provider').onchange=plan;
       attachAutocomplete('start','startList'); attachAutocomplete('end','endList');
+      loadStored();
     </script>
   </div>
 </body>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "fuel-route-planner",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node -e \"console.log('no tests')\""
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "sqlite": "^4.2.1",
+    "sqlite3": "^5.1.6"
+  }
+}
+

--- a/server.js
+++ b/server.js
@@ -1,0 +1,63 @@
+import express from 'express';
+import cors from 'cors';
+import sqlite3 from 'sqlite3';
+import { open } from 'sqlite';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+app.use(express.static(__dirname));
+
+let db;
+(async () => {
+  db = await open({
+    filename: path.join(__dirname, 'data.db'),
+    driver: sqlite3.Database
+  });
+  await db.exec(`CREATE TABLE IF NOT EXISTS routes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    start TEXT NOT NULL,
+    end TEXT NOT NULL,
+    favorite INTEGER DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  );`);
+})();
+
+app.get('/api/routes', async (req, res) => {
+  const rows = await db.all('SELECT id,start,end,favorite FROM routes ORDER BY created_at DESC LIMIT 10');
+  res.json(rows);
+});
+
+app.post('/api/routes', async (req, res) => {
+  const { start, end } = req.body;
+  if (!start || !end) return res.status(400).json({ error: 'start and end required' });
+  await db.run('INSERT INTO routes (start,end) VALUES (?,?)', [start, end]);
+  await db.run('DELETE FROM routes WHERE id NOT IN (SELECT id FROM routes ORDER BY created_at DESC LIMIT 10)');
+  res.json({ status: 'ok' });
+});
+
+app.get('/api/favorites', async (req, res) => {
+  const rows = await db.all('SELECT id,start,end FROM routes WHERE favorite=1 ORDER BY created_at DESC');
+  res.json(rows);
+});
+
+app.post('/api/favorites', async (req, res) => {
+  const { id } = req.body;
+  if (!id) return res.status(400).json({ error: 'id required' });
+  await db.run('UPDATE routes SET favorite=1 WHERE id=?', id);
+  res.json({ status: 'ok' });
+});
+
+app.delete('/api/favorites/:id', async (req, res) => {
+  const { id } = req.params;
+  await db.run('UPDATE routes SET favorite=0 WHERE id=?', id);
+  res.json({ status: 'ok' });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Server running on http://localhost:${PORT}`));
+


### PR DESCRIPTION
## Summary
- Add Favorites and Recent Routes sections to the UI
- Store planned routes and favorites via new Express/SQLite backend
- Document backend usage and ignore DB artifacts

## Testing
- `npm install` *(fails: 403 Forbidden - registry access blocked)*
- `node server.js` *(fails: Cannot find package 'express')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68abfcc6686483319e61c88024b4ee21