### PR TITLE
style: add lower navigation styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     .row{display:grid;grid-template-columns:1fr 1fr;gap:10px}
     .row-3{display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px}
     .tools{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
+    .react-component .lower-navigation{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
     input,select,button{font-size:14px}
     input,select{width:100%;padding:10px 12px;border-radius:12px;border:1px solid var(--border);background:#0b1320;color:#e5e7eb}
     .btn{padding:10px 14px;border-radius:12px;border:1px solid var(--border);background:#14213a;color:#e5e7eb;cursor:pointer}


### PR DESCRIPTION
## Summary
- integrate `.react-component .lower-navigation` style into static page while keeping provider selector and Google Maps linking

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden to fetch package)*
- `cd frontend && npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68ad37202b348331bf1dfebdd0387c74