### PR TITLE
Add theme toggle and integrate constants

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
         <label>Max detour (mi)
           <input id="detour" type="number" step="0.5" value="5" style="width:120px" />
         </label>
+        <button id="themeToggle" type="button" class="btn">Light</button>
       </div>
     </header>
 
@@ -127,9 +128,37 @@
     </section>
 
     <script>
-      const $=id=>document.getElementById(id);
-      const MI_PER_M=1/1609.344; 
-      
+      const $ = id => document.getElementById(id);
+      const MI_PER_M = 1 / 1609.344;
+      const GEOAPIFY_KEY = '...';
+      const EIA_KEY = '...';
+      const themeBtn = $('themeToggle');
+      function applyTheme(mode) {
+        const root = document.documentElement;
+        if (mode === 'light') {
+          root.style.setProperty('--bg', '#ffffff');
+          root.style.setProperty('--panel', '#f1f5f9');
+          root.style.setProperty('--muted', '#64748b');
+          root.style.setProperty('--text', '#1e293b');
+          root.style.setProperty('--accent', '#3b82f6');
+          root.style.setProperty('--border', 'rgba(148,163,184,.3)');
+        } else {
+          root.style.setProperty('--bg', '#0b1120');
+          root.style.setProperty('--panel', '#0f172a');
+          root.style.setProperty('--muted', '#94a3b8');
+          root.style.setProperty('--text', '#e5e7eb');
+          root.style.setProperty('--accent', '#3b82f6');
+          root.style.setProperty('--border', 'rgba(148,163,184,.18)');
+        }
+        localStorage.setItem('theme', mode);
+        themeBtn.textContent = mode === 'light' ? 'Dark' : 'Light';
+      }
+      applyTheme(localStorage.getItem('theme') || 'dark');
+      themeBtn.onclick = () => {
+        const next = themeBtn.textContent === 'Light' ? 'light' : 'dark';
+        applyTheme(next);
+      };
+
       function note(kind,msg){ const el=$('alerts'); el.className = 'small '+(kind==='ok'?'ok':kind==='error'?'error':'muted'); el.innerHTML=msg; }
 
       // Autocomplete (Geoapify)


### PR DESCRIPTION
## Summary
- Add theme toggle button and logic using CSS variables
- Keep MI_PER_M constant and add API key placeholders with theme initialization

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cd frontend && npm test` *(fails: Missing script "test")*
- `cd frontend && npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68b39d2d711c8331af1dad1e4b1d79e3