### PR TITLE
Add route provider selection

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,11 +8,27 @@ const App: React.FC = () => {
   const [stations, setStations] = useState<Station[]>([]);
   const [plan, setPlan] = useState<PlanResult | null>(null);
 
-  const handlePlan = (values: RouteFormValues) => {
+  const handlePlan = async (values: RouteFormValues) => {
     console.log('Plan request', values);
-    // Integration with backend will populate stations and plan
-    setStations([]);
-    setPlan(null);
+    try {
+      const res = await fetch(`/api/plan?provider=${values.routeProvider}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setStations(data.stations || []);
+        setPlan(data.plan || null);
+      } else {
+        setStations([]);
+        setPlan(null);
+      }
+    } catch (err) {
+      console.error('Plan error', err);
+      setStations([]);
+      setPlan(null);
+    }
   };
 
   return (

--- a/frontend/src/components/RouteForm.tsx
+++ b/frontend/src/components/RouteForm.tsx
@@ -19,6 +19,7 @@ const RouteForm: React.FC<Props> = ({ onPlan }) => {
     govSpeed: 70,
     wind: undefined,
     driverCost: 122,
+    routeProvider: 'geoapify',
   });
 
   const update = (e: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
@@ -44,6 +45,19 @@ const RouteForm: React.FC<Props> = ({ onPlan }) => {
         <label>
           <span className="small muted">Destination (exact address OK)</span>
           <input name="end" value={values.end} onChange={update} />
+        </label>
+      </div>
+      <div className="row" style={{ marginTop: 8 }}>
+        <label>
+          <span className="small muted">Route provider</span>
+          <select
+            name="routeProvider"
+            value={values.routeProvider}
+            onChange={update}
+          >
+            <option value="geoapify">geoapify</option>
+            <option value="google">google</option>
+          </select>
         </label>
       </div>
       <div className="row-3" style={{ marginTop: 8 }}>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -11,6 +11,7 @@ export interface RouteFormValues {
   govSpeed: number;
   wind?: number;
   driverCost: number;
+  routeProvider: 'geoapify' | 'google';
 }
 
 export interface Station {


### PR DESCRIPTION
## Summary
- Add route provider field in RouteForm with default and dropdown for Geoapify or Google
- Extend RouteFormValues type with routeProvider
- Send selected provider in backend plan request

## Testing
- `npm test` (fails: Invalid package.json: Unexpected token "diff")
- `npm --prefix frontend test` (fails: Missing script "test")
- `npm --prefix frontend run build` (fails: Unexpected "diff" in JSON)


------
https://chatgpt.com/codex/tasks/task_b_68b3b2bf09c083319b2511e6c28273b8