### PR TITLE
feat: add layout with sidebar and top bar

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import RouteForm from './components/RouteForm';
 import StationList from './components/StationList';
 import PlanSummary from './components/PlanSummary';
+import Layout from './components/Layout';
 import { Station, PlanResult, RouteFormValues } from './types';
 
 const App: React.FC = () => {
@@ -32,11 +33,11 @@ const App: React.FC = () => {
   };
 
   return (
-    <div className="wrap">
+    <Layout>
       <RouteForm onPlan={handlePlan} />
       <StationList stations={stations} />
       <PlanSummary result={plan} />
-    </div>
+    </Layout>
   );
 };
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+const Layout: React.FC<LayoutProps> = ({ children }) => {
+  return (
+    <div className="layout">
+      <aside className="sidebar">
+        <nav>
+          <ul>
+            <li className="nav-item">Dashboard</li>
+            <li className="nav-item">Courses</li>
+            <li className="nav-item">Students</li>
+          </ul>
+        </nav>
+      </aside>
+      <header className="top-bar">
+        <h1>Fuel Route Planner</h1>
+      </header>
+      <main className="content">
+        <div className="wrap">{children}</div>
+      </main>
+    </div>
+  );
+};
+
+export default Layout;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -21,3 +21,9 @@ input,select{width:100%;padding:10px 12px;border-radius:12px;border:1px solid va
 .loading{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.35);z-index:9999}
 .spinner{width:36px;height:36px;border:4px solid rgba(255,255,255,.3);border-top-color:#3b82f6;border-radius:50%;animation:spin 1s linear infinite}
 @keyframes spin{to{transform:rotate(360deg)}}
+.layout{display:grid;grid-template-columns:200px 1fr;grid-template-rows:60px 1fr;grid-template-areas:"sidebar topbar" "sidebar main";height:100vh}
+.sidebar{grid-area:sidebar;background:var(--panel);display:flex;flex-direction:column;padding:1rem;border-right:1px solid var(--border)}
+.sidebar ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:.5rem}
+.nav-item{cursor:pointer;padding:.5rem 0}
+.top-bar{grid-area:topbar;background:var(--panel);display:flex;align-items:center;padding:0 1rem;border-bottom:1px solid var(--border)}
+.content{grid-area:main;padding:1rem;overflow-y:auto}


### PR DESCRIPTION
## Summary
- add Layout component with sidebar navigation and top bar
- wrap existing RouteForm, StationList and PlanSummary in the new layout
- style layout with CSS grid and flex for sidebar and top bar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Unexpected "diff" in JSON: ../package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b3b9c1e6308331bee9c5f9474116bc