### PR TITLE
Refactor route form layout

### DIFF
--- a/frontend/src/components/RouteForm.tsx
+++ b/frontend/src/components/RouteForm.tsx
@@ -21,6 +21,7 @@ const RouteForm: React.FC<Props> = ({ onPlan }) => {
     driverCost: 122,
     routeProvider: 'geoapify',
   });
+  const [errors, setErrors] = useState<Record<string, string>>({});
 
   const update = (e: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { name, value, type } = e.target;
@@ -32,140 +33,171 @@ const RouteForm: React.FC<Props> = ({ onPlan }) => {
 
   const submit = (e: FormEvent) => {
     e.preventDefault();
-    onPlan(values);
+    const errs: Record<string, string> = {};
+    if (!values.start.trim()) errs.start = 'Start is required';
+    if (!values.end.trim()) errs.end = 'Destination is required';
+    setErrors(errs);
+    if (Object.keys(errs).length === 0) {
+      onPlan(values);
+    }
   };
 
   return (
-    <form className="card" onSubmit={submit} style={{ marginTop: 12 }}>
-      <div className="row">
-        <label>
-          <span className="small muted">Start (exact address OK)</span>
-          <input name="start" value={values.start} onChange={update} />
-        </label>
-        <label>
-          <span className="small muted">Destination (exact address OK)</span>
-          <input name="end" value={values.end} onChange={update} />
-        </label>
-      </div>
-      <div className="row" style={{ marginTop: 8 }}>
-        <label>
-          <span className="small muted">Route provider</span>
-          <select
-            name="routeProvider"
-            value={values.routeProvider}
-            onChange={update}
-          >
-            <option value="geoapify">geoapify</option>
-            <option value="google">google</option>
-          </select>
-        </label>
-      </div>
-      <div className="row-3" style={{ marginTop: 8 }}>
-        <label>
-          <span className="small muted">Base MPG</span>
-          <input
-            name="mpg"
-            type="number"
-            step="0.1"
-            value={values.mpg}
-            onChange={update}
-          />
-        </label>
-        <label>
-          <span className="small muted">Tank size (gal)</span>
-          <input
-            name="tank"
-            type="number"
-            step="1"
-            value={values.tank}
-            onChange={update}
-          />
-        </label>
-        <label>
-          <span className="small muted">Current fuel</span>
-          <div className="row" style={{ gridTemplateColumns: '2fr 1fr' }}>
+    <form className="card mt-12" onSubmit={submit}>
+      <fieldset className="section">
+        <legend>Route</legend>
+        <div className="row">
+          <label>
+            <span className="small muted">Start 📍</span>
             <input
-              name="fuelVal"
-              type="number"
-              step="0.1"
-              value={values.fuelVal}
+              name="start"
+              placeholder="City or address"
+              value={values.start}
               onChange={update}
             />
+            {errors.start && (
+              <span className="error-text">{errors.start}</span>
+            )}
+          </label>
+          <label>
+            <span className="small muted">Destination 🎯</span>
+            <input
+              name="end"
+              placeholder="City or address"
+              value={values.end}
+              onChange={update}
+            />
+            {errors.end && (
+              <span className="error-text">{errors.end}</span>
+            )}
+          </label>
+        </div>
+        <div className="row mt-8">
+          <label>
+            <span className="small muted">Route provider</span>
             <select
-              name="fuelUnit"
-              value={values.fuelUnit}
+              name="routeProvider"
+              value={values.routeProvider}
               onChange={update}
             >
-              <option value="gal">gal</option>
-              <option value="pct">% of tank</option>
+              <option value="geoapify">geoapify</option>
+              <option value="google">google</option>
             </select>
-          </div>
-        </label>
-      </div>
-      <div className="row-3" style={{ marginTop: 8 }}>
-        <label>
-          <span className="small muted">Reserve buffer (miles)</span>
-          <input
-            name="reserve"
-            type="number"
-            step="1"
-            value={values.reserve}
-            onChange={update}
-          />
-        </label>
-        <label>
-          <span className="small muted">Gross weight (lbs, optional)</span>
-          <input
-            name="weight"
-            type="number"
-            step="100"
-            value={values.weight ?? ''}
-            onChange={update}
-          />
-        </label>
-        <label>
-          <span className="small muted">Terrain</span>
-          <select name="terrain" value={values.terrain} onChange={update}>
-            <option value="flat">Flat</option>
-            <option value="rolling">Rolling</option>
-            <option value="hilly">Hilly</option>
-            <option value="mountain">Mountain</option>
-          </select>
-        </label>
-      </div>
-      <div className="row-3" style={{ marginTop: 8 }}>
-        <label>
-          <span className="small muted">Governed speed (mph)</span>
-          <input
-            name="govSpeed"
-            type="number"
-            step="1"
-            value={values.govSpeed}
-            onChange={update}
-          />
-        </label>
-        <label>
-          <span className="small muted">Headwind (mph, optional)</span>
-          <input
-            name="wind"
-            type="number"
-            step="1"
-            value={values.wind ?? ''}
-            onChange={update}
-          />
-        </label>
-        <label>
-          <span className="small muted">Driver cost ($/hr)</span>
-          <input
-            name="driverCost"
-            type="number"
-            step="1"
-            value={values.driverCost}
-            onChange={update}
-          />
-        </label>
-      </div>
-      <div style={{ marginTop: 8 }}>
+          </label>
+        </div>
+      </fieldset>
+      <fieldset className="section mt-12">
+        <legend>Vehicle</legend>
+        <div className="row-3">
+          <label>
+            <span className="small muted">Base MPG</span>
+            <input
+              name="mpg"
+              type="number"
+              step="0.1"
+              value={values.mpg}
+              onChange={update}
+            />
+          </label>
+          <label>
+            <span className="small muted">Tank size (gal)</span>
+            <input
+              name="tank"
+              type="number"
+              step="1"
+              value={values.tank}
+              onChange={update}
+            />
+          </label>
+          <label>
+            <span className="small muted">Current fuel</span>
+            <div className="fuel-row">
+              <input
+                name="fuelVal"
+                type="number"
+                step="0.1"
+                value={values.fuelVal}
+                onChange={update}
+              />
+              <select
+                name="fuelUnit"
+                value={values.fuelUnit}
+                onChange={update}
+              >
+                <option value="gal">gal</option>
+                <option value="pct">% of tank</option>
+              </select>
+            </div>
+          </label>
+        </div>
+        <div className="row-3 mt-8">
+          <label>
+            <span className="small muted">Reserve buffer (miles)</span>
+            <input
+              name="reserve"
+              type="number"
+              step="1"
+              value={values.reserve}
+              onChange={update}
+            />
+          </label>
+          <label>
+            <span className="small muted">Gross weight (lbs, optional)</span>
+            <input
+              name="weight"
+              type="number"
+              step="100"
+              value={values.weight ?? ''}
+              onChange={update}
+            />
+          </label>
+          <label>
+            <span className="small muted">Terrain</span>
+            <select name="terrain" value={values.terrain} onChange={update}>
+              <option value="flat">Flat</option>
+              <option value="rolling">Rolling</option>
+              <option value="hilly">Hilly</option>
+              <option value="mountain">Mountain</option>
+            </select>
+          </label>
+        </div>
+      </fieldset>
+      <fieldset className="section mt-12">
+        <legend>Conditions</legend>
+        <div className="row-3">
+          <label>
+            <span className="small muted">Governed speed (mph)</span>
+            <input
+              name="govSpeed"
+              type="number"
+              step="1"
+              value={values.govSpeed}
+              onChange={update}
+            />
+          </label>
+          <label>
+            <span className="small muted">Headwind (mph, optional)</span>
+            <input
+              name="wind"
+              type="number"
+              step="1"
+              value={values.wind ?? ''}
+              onChange={update}
+            />
+          </label>
+          <label>
+            <span className="small muted">Driver cost ($/hr)</span>
+            <input
+              name="driverCost"
+              type="number"
+              step="1"
+              value={values.driverCost}
+              onChange={update}
+            />
+          </label>
+        </div>
+      </fieldset>
+      <div className="mt-8">
         <button type="submit" className="btn primary">
           Plan Route
         </button>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -26,6 +26,12 @@ input,select{width:100%;padding:10px 12px;border-radius:12px;border:1px solid va
 .loading{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.35);z-index:9999}
 .spinner{width:36px;height:36px;border:4px solid rgba(255,255,255,.3);border-top-color:#3b82f6;border-radius:50%;animation:spin 1s linear infinite}
 @keyframes spin{to{transform:rotate(360deg)}}
+.layout{display:grid;grid-template-columns:200px 1fr;grid-template-rows:60px 1fr;grid-template-areas:"sidebar topbar" "sidebar main";height:100vh}
+.sidebar{grid-area:sidebar;background:var(--panel);display:flex;flex-direction:column;padding:1rem;border-right:1px solid var(--border)}
+.sidebar ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:.5rem}
+.nav-item{cursor:pointer;padding:.5rem 0}
+.top-bar{grid-area:topbar;background:var(--panel);display:flex;align-items:center;padding:0 1rem;border-bottom:1px solid var(--border)}
+.content{grid-area:main;padding:1rem;overflow-y:auto}
 @media (max-width:600px){
  .row{grid-template-columns:1fr}
  .row-3{grid-template-columns:1fr}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,6 +4,11 @@ body{margin:0;font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,
 .card{background:linear-gradient(to bottom right, rgba(15,23,42,.92), rgba(2,6,23,.92));border:1px solid var(--border);border-radius:16px;padding:14px}
 .row{display:grid;grid-template-columns:1fr 1fr;gap:10px}
 .row-3{display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px}
+.fuel-row{display:grid;grid-template-columns:2fr 1fr;gap:10px}
+.mt-8{margin-top:8px}
+.mt-12{margin-top:12px}
+.section{border:1px solid var(--border);border-radius:12px;padding:10px}
+.error-text{color:#fecaca;font-size:12px}
 .tools{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
 input,select,button{font-size:14px}
 input,select{width:100%;padding:10px 12px;border-radius:12px;border:1px solid var(--border);background:#0b1320;color:#e5e7eb}
@@ -21,3 +26,8 @@ input,select{width:100%;padding:10px 12px;border-radius:12px;border:1px solid va
 .loading{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.35);z-index:9999}
 .spinner{width:36px;height:36px;border:4px solid rgba(255,255,255,.3);border-top-color:#3b82f6;border-radius:50%;animation:spin 1s linear infinite}
 @keyframes spin{to{transform:rotate(360deg)}}
+@media (max-width:600px){
+ .row{grid-template-columns:1fr}
+ .row-3{grid-template-columns:1fr}
+ .fuel-row{grid-template-columns:1fr 1fr}
+}

--- a/package.json
+++ b/package.json
@@ -1,19 +1,14 @@
-diff --git a//dev/null b/package.json
-index 0000000000000000000000000000000000000000..8429d9aa686c1bb9bc669bad8a76bf6a09c4c6b1 100644
---- a//dev/null
-+++ b/package.json
-@@ -0,0 +1,14 @@
-+{
-+  "name": "fuel-route-planner",
-+  "version": "1.0.0",
-+  "description": "A self-contained web app for planning semi-truck fuel routes with: - **Truck-aware routing** (Geoapify Routing API) - **Fuel stop discovery** (Geoapify Places API) - **Diesel price estimates** from the **U.S. Energy Information Administration (EIA)** - **AI-based recommendations** that adjust for weight, terrain, governed speed, wind, and reserve buffer.",
-+  "main": "server.js",
-+  "scripts": {
-+    "start": "node server.js",
-+    "test": "node -c server.js"
-+  },
-+  "keywords": [],
-+  "author": "",
-+  "license": "ISC",
-+  "type": "commonjs"
-+}
+{
+  "name": "fuel-route-planner",
+  "version": "1.0.0",
+  "description": "A self-contained web app for planning semi-truck fuel routes with: - **Truck-aware routing** (Geoapify Routing API) - **Fuel stop discovery** (Geoapify Places API) - **Diesel price estimates** from the **U.S. Energy Information Administration (EIA)** - **AI-based recommendations** that adjust for weight, terrain, governed speed, wind, and reserve buffer.",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node -c server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,109 +1,104 @@
-diff --git a//dev/null b/server.js
-index 0000000000000000000000000000000000000000..fbce7866fea20289646590850192f837ee3c24b9 100644
---- a//dev/null
-+++ b/server.js
-@@ -0,0 +1,104 @@
-+const http = require('http');
-+const {URL} = require('url');
-+
-+const GOOGLE_KEY = process.env.GOOGLE_MAPS_API_KEY || '';
-+
-+function send(res, status, obj){
-+  res.statusCode = status;
-+  res.setHeader('Content-Type','application/json');
-+  res.end(JSON.stringify(obj));
-+}
-+
-+function decodePolyline(str){
-+  let index=0, lat=0, lng=0, coordinates=[];
-+  while(index < str.length){
-+    let result=0, shift=0, b;
-+    do{ b=str.charCodeAt(index++)-63; result |= (b & 0x1f) << shift; shift +=5; }while(b>=0x20);
-+    const dlat = ((result & 1)? ~(result>>1):(result>>1));
-+    lat += dlat;
-+    result=0; shift=0;
-+    do{ b=str.charCodeAt(index++)-63; result |= (b & 0x1f) << shift; shift +=5; }while(b>=0x20);
-+    const dlng = ((result & 1)? ~(result>>1):(result>>1));
-+    lng += dlng;
-+    coordinates.push([lng/1e5, lat/1e5]);
-+  }
-+  return coordinates;
-+}
-+
-+async function geocode(q){
-+  if(!GOOGLE_KEY) throw new Error('Missing API key');
-+  const url = new URL('https://maps.googleapis.com/maps/api/geocode/json');
-+  url.searchParams.set('address', q);
-+  url.searchParams.set('key', GOOGLE_KEY);
-+  const j = await fetch(url).then(r=>r.json());
-+  const loc = j.results?.[0]?.geometry?.location;
-+  if(!loc) throw new Error('not found');
-+  return {lat: loc.lat, lon: loc.lng};
-+}
-+
-+async function directions(origin,destination){
-+  if(!GOOGLE_KEY) throw new Error('Missing API key');
-+  const url = new URL('https://maps.googleapis.com/maps/api/directions/json');
-+  url.searchParams.set('origin', origin);
-+  url.searchParams.set('destination', destination);
-+  url.searchParams.set('key', GOOGLE_KEY);
-+  const j = await fetch(url).then(r=>r.json());
-+  const points = j.routes?.[0]?.overview_polyline?.points;
-+  if(!points) throw new Error('no route');
-+  return {coordinates: decodePolyline(points)};
-+}
-+
-+async function stations(path, detour){
-+  if(!GOOGLE_KEY) throw new Error('Missing API key');
-+  const radius = Math.min(detour||5,50)*1609;
-+  const results = new Map();
-+  for(let i=0;i<path.length;i+=25){
-+    const [lon,lat] = path[i];
-+    const url = new URL('https://maps.googleapis.com/maps/api/place/nearbysearch/json');
-+    url.searchParams.set('location', `${lat},${lon}`);
-+    url.searchParams.set('radius', radius);
-+    url.searchParams.set('keyword', 'truck stop');
-+    url.searchParams.set('key', GOOGLE_KEY);
-+    const j = await fetch(url).then(r=>r.json());
-+    (j.results||[]).forEach(p=>{
-+      if(results.has(p.place_id)) return;
-+      results.set(p.place_id,{id:p.place_id,name:p.name,brand:p.name,lat:p.geometry.location.lat,lon:p.geometry.location.lng,addr:p.vicinity,truckFriendly:true});
-+    });
-+  }
-+  return Array.from(results.values());
-+}
-+
-+const server = http.createServer(async (req,res)=>{
-+  try{
-+    const u = new URL(req.url, 'http://localhost');
-+    if(req.method==='GET' && u.pathname==='/api/google/geocode'){
-+      const q = u.searchParams.get('q');
-+      const out = await geocode(q);
-+      return send(res,200,out);
-+    }
-+    if(req.method==='GET' && u.pathname==='/api/google/directions'){
-+      const origin = u.searchParams.get('origin');
-+      const dest = u.searchParams.get('destination');
-+      const out = await directions(origin,dest);
-+      return send(res,200,out);
-+    }
-+    if(req.method==='POST' && u.pathname==='/api/google/stations'){
-+      let body='';
-+      req.on('data',d=>body+=d);
-+      req.on('end', async ()=>{
-+        try{
-+          const j=JSON.parse(body||'{}');
-+          const out = await stations(j.path||[], j.detour);
-+          send(res,200,out);
-+        }catch(e){ send(res,500,{error:e.message}); }
-+      });
-+      return;
-+    }
-+    send(res,404,{error:'not found'});
-+  }catch(e){
-+    send(res,500,{error:e.message});
-+  }
-+});
-+
-+const port = process.env.PORT || 3000;
-+server.listen(port, ()=> console.log('Server listening on '+port));
+const http = require('http');
+const {URL} = require('url');
+
+const GOOGLE_KEY = process.env.GOOGLE_MAPS_API_KEY || '';
+
+function send(res, status, obj){
+  res.statusCode = status;
+  res.setHeader('Content-Type','application/json');
+  res.end(JSON.stringify(obj));
+}
+
+function decodePolyline(str){
+  let index=0, lat=0, lng=0, coordinates=[];
+  while(index < str.length){
+    let result=0, shift=0, b;
+    do{ b=str.charCodeAt(index++)-63; result |= (b & 0x1f) << shift; shift +=5; }while(b>=0x20);
+    const dlat = ((result & 1)? ~(result>>1):(result>>1));
+    lat += dlat;
+    result=0; shift=0;
+    do{ b=str.charCodeAt(index++)-63; result |= (b & 0x1f) << shift; shift +=5; }while(b>=0x20);
+    const dlng = ((result & 1)? ~(result>>1):(result>>1));
+    lng += dlng;
+    coordinates.push([lng/1e5, lat/1e5]);
+  }
+  return coordinates;
+}
+
+async function geocode(q){
+  if(!GOOGLE_KEY) throw new Error('Missing API key');
+  const url = new URL('https://maps.googleapis.com/maps/api/geocode/json');
+  url.searchParams.set('address', q);
+  url.searchParams.set('key', GOOGLE_KEY);
+  const j = await fetch(url).then(r=>r.json());
+  const loc = j.results?.[0]?.geometry?.location;
+  if(!loc) throw new Error('not found');
+  return {lat: loc.lat, lon: loc.lng};
+}
+
+async function directions(origin,destination){
+  if(!GOOGLE_KEY) throw new Error('Missing API key');
+  const url = new URL('https://maps.googleapis.com/maps/api/directions/json');
+  url.searchParams.set('origin', origin);
+  url.searchParams.set('destination', destination);
+  url.searchParams.set('key', GOOGLE_KEY);
+  const j = await fetch(url).then(r=>r.json());
+  const points = j.routes?.[0]?.overview_polyline?.points;
+  if(!points) throw new Error('no route');
+  return {coordinates: decodePolyline(points)};
+}
+
+async function stations(path, detour){
+  if(!GOOGLE_KEY) throw new Error('Missing API key');
+  const radius = Math.min(detour||5,50)*1609;
+  const results = new Map();
+  for(let i=0;i<path.length;i+=25){
+    const [lon,lat] = path[i];
+    const url = new URL('https://maps.googleapis.com/maps/api/place/nearbysearch/json');
+    url.searchParams.set('location', `${lat},${lon}`);
+    url.searchParams.set('radius', radius);
+    url.searchParams.set('keyword', 'truck stop');
+    url.searchParams.set('key', GOOGLE_KEY);
+    const j = await fetch(url).then(r=>r.json());
+    (j.results||[]).forEach(p=>{
+      if(results.has(p.place_id)) return;
+      results.set(p.place_id,{id:p.place_id,name:p.name,brand:p.name,lat:p.geometry.location.lat,lon:p.geometry.location.lng,addr:p.vicinity,truckFriendly:true});
+    });
+  }
+  return Array.from(results.values());
+}
+
+const server = http.createServer(async (req,res)=>{
+  try{
+    const u = new URL(req.url, 'http://localhost');
+    if(req.method==='GET' && u.pathname==='/api/google/geocode'){
+      const q = u.searchParams.get('q');
+      const out = await geocode(q);
+      return send(res,200,out);
+    }
+    if(req.method==='GET' && u.pathname==='/api/google/directions'){
+      const origin = u.searchParams.get('origin');
+      const dest = u.searchParams.get('destination');
+      const out = await directions(origin,dest);
+      return send(res,200,out);
+    }
+    if(req.method==='POST' && u.pathname==='/api/google/stations'){
+      let body='';
+      req.on('data',d=>body+=d);
+      req.on('end', async ()=>{
+        try{
+          const j=JSON.parse(body||'{}');
+          const out = await stations(j.path||[], j.detour);
+          send(res,200,out);
+        }catch(e){ send(res,500,{error:e.message}); }
+      });
+      return;
+    }
+    send(res,404,{error:'not found'});
+  }catch(e){
+    send(res,500,{error:e.message});
+  }
+});
+
+const port = process.env.PORT || 3000;
+server.listen(port, ()=> console.log('Server listening on '+port));


### PR DESCRIPTION
## Summary
- organize route planning fields into Route, Vehicle, and Conditions fieldsets with placeholders and icons
- move inline styles to `index.css` with utility classes and mobile media queries
- add simple validation for start and destination inputs with error messaging

## Testing
- ❌ `npm test` (invalid package.json)
- ❌ `npm --prefix frontend test` (missing script)
- ❌ `npm --prefix frontend run build` (Unexpected "diff" in JSON)
- ✅ `npx tsc -p frontend/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_b_68b3b9d0e7fc83319ad8b4214e67b474