### PR TITLE
Add metric charts and plan step styling

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "chart.js": "^4.4.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/frontend/src/components/MetricBar.tsx
+++ b/frontend/src/components/MetricBar.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useRef } from 'react';
+import { Chart, BarElement, CategoryScale, LinearScale } from 'chart.js';
+
+Chart.register(BarElement, CategoryScale, LinearScale);
+
+interface Props {
+  value: number;
+  max: number;
+}
+
+const MetricBar: React.FC<Props> = ({ value, max }) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    if (!canvasRef.current) return;
+    const chart = new Chart(canvasRef.current, {
+      type: 'bar',
+      data: {
+        labels: [''],
+        datasets: [
+          {
+            data: [value],
+            backgroundColor: '#3b82f6',
+            barPercentage: 1,
+            categoryPercentage: 1,
+          },
+        ],
+      },
+      options: {
+        indexAxis: 'y',
+        animation: false,
+        plugins: { legend: { display: false }, tooltip: { enabled: false } },
+        scales: {
+          x: { display: false, max, beginAtZero: true },
+          y: { display: false },
+        },
+      },
+    });
+    return () => chart.destroy();
+  }, [value, max]);
+
+  return <canvas ref={canvasRef} width={120} height={16} className="metric-chart" />;
+};
+
+export default MetricBar;
+

--- a/frontend/src/components/PlanSummary.tsx
+++ b/frontend/src/components/PlanSummary.tsx
@@ -1,53 +1,69 @@
 import React from 'react';
 import { PlanResult } from '../types';
+import MetricBar from './MetricBar';
 
 interface Props {
   result: PlanResult | null;
 }
 
-const PlanSummary: React.FC<Props> = ({ result }) => (
-  <section className="card" style={{ marginTop: 12 }}>
-    <h2>Plan Summary</h2>
-    {!result ? (
-      <div className="muted">No plan calculated.</div>
-    ) : (
-      <>
-        <div className="kvs">
-          <div>Effective MPG</div>
-          <div className="mono">{result.mpgEff.toFixed(2)}</div>
-          <div>Max range (full tank)</div>
-          <div className="mono">{result.maxRange.toFixed(0)} mi</div>
-          <div>Total route</div>
-          <div className="mono">{result.totalMiles.toFixed(0)} mi</div>
-        </div>
-        <div className="list" style={{ marginTop: 8 }}>
-          {result.plan.length === 0 ? (
-            <div className="muted">No actions needed.</div>
-          ) : (
-            result.plan.map((step, i) =>
-              step.type === 'stop' ? (
-                <div className="station" key={i}>
-                  <div>
-                    <b>Stop at:</b> {step.station.name}
+const PlanSummary: React.FC<Props> = ({ result }) => {
+  const maxMiles = result ? Math.max(result.maxRange, result.totalMiles) : 0;
+  return (
+    <section className="card mt-12">
+      <h2>Plan Summary</h2>
+      {!result ? (
+        <div className="muted">No plan calculated.</div>
+      ) : (
+        <>
+          <div className="kvs">
+            <div>Effective MPG</div>
+            <div>
+              <div className="mono">{result.mpgEff.toFixed(2)}</div>
+              <MetricBar value={result.mpgEff} max={15} />
+            </div>
+            <div>Max range (full tank)</div>
+            <div>
+              <div className="mono">{result.maxRange.toFixed(0)} mi</div>
+              <MetricBar value={result.maxRange} max={maxMiles} />
+            </div>
+            <div>Total route</div>
+            <div>
+              <div className="mono">{result.totalMiles.toFixed(0)} mi</div>
+              <MetricBar value={result.totalMiles} max={maxMiles} />
+            </div>
+          </div>
+          <div className="list mt-8">
+            {result.plan.length === 0 ? (
+              <div className="muted">No actions needed.</div>
+            ) : (
+              result.plan.map((step, i) =>
+                step.type === 'stop' ? (
+                  <div className="plan-step stop" key={i}>
+                    <span className="icon">⛽</span>
                     <div>
-                      Buy <b>{step.gallons.toFixed(1)} gal</b>
-                      {step.cost != null
-                        ? ` @ ~$${step.station.dieselPrice?.toFixed(3)}/gal ≈ $${step.cost.toFixed(2)}`
-                        : ''}
+                      <b>Stop at:</b> {step.station.name}
+                      <div>
+                        Buy <b>{step.gallons.toFixed(1)} gal</b>
+                        {step.cost != null
+                          ? ` @ ~$${step.station.dieselPrice?.toFixed(3)}/gal ≈ $${step.cost.toFixed(2)}`
+                          : ''}
+                      </div>
                     </div>
                   </div>
-                </div>
-              ) : (
-                <div className="station" key={i}>
-                  <div>{step.action}</div>
-                </div>
+                ) : (
+                  <div className="plan-step action" key={i}>
+                    <span className="icon">➡️</span>
+                    <div>{step.action}</div>
+                  </div>
+                )
               )
-            )
-          )}
-        </div>
-      </>
-    )}
-  </section>
-);
+            )}
+          </div>
+        </>
+      )}
+    </section>
+  );
+};
 
 export default PlanSummary;
+

--- a/frontend/src/components/RouteForm.tsx
+++ b/frontend/src/components/RouteForm.tsx
@@ -36,7 +36,7 @@ const RouteForm: React.FC<Props> = ({ onPlan }) => {
   };
 
   return (
-    <form className="card" onSubmit={submit} style={{ marginTop: 12 }}>
+    <form className="card mt-12" onSubmit={submit}>
       <div className="row">
         <label>
           <span className="small muted">Start (exact address OK)</span>
@@ -47,7 +47,7 @@ const RouteForm: React.FC<Props> = ({ onPlan }) => {
           <input name="end" value={values.end} onChange={update} />
         </label>
       </div>
-      <div className="row" style={{ marginTop: 8 }}>
+      <div className="row mt-8">
         <label>
           <span className="small muted">Route provider</span>
           <select
@@ -60,7 +60,7 @@ const RouteForm: React.FC<Props> = ({ onPlan }) => {
           </select>
         </label>
       </div>
-      <div className="row-3" style={{ marginTop: 8 }}>
+      <div className="row-3 mt-8">
         <label>
           <span className="small muted">Base MPG</span>
           <input
@@ -102,7 +102,7 @@ const RouteForm: React.FC<Props> = ({ onPlan }) => {
           </div>
         </label>
       </div>
-      <div className="row-3" style={{ marginTop: 8 }}>
+      <div className="row-3 mt-8">
         <label>
           <span className="small muted">Reserve buffer (miles)</span>
           <input
@@ -133,7 +133,7 @@ const RouteForm: React.FC<Props> = ({ onPlan }) => {
           </select>
         </label>
       </div>
-      <div className="row-3" style={{ marginTop: 8 }}>
+      <div className="row-3 mt-8">
         <label>
           <span className="small muted">Governed speed (mph)</span>
           <input
@@ -165,10 +165,8 @@ const RouteForm: React.FC<Props> = ({ onPlan }) => {
           />
         </label>
       </div>
-      <div style={{ marginTop: 8 }}>
-        <button type="submit" className="btn primary">
-          Plan Route
-        </button>
+      <div className="mt-8">
+        <button type="submit" className="btn primary">Plan Route</button>
       </div>
     </form>
   );

--- a/frontend/src/components/StationList.tsx
+++ b/frontend/src/components/StationList.tsx
@@ -6,7 +6,7 @@ interface Props {
 }
 
 const StationList: React.FC<Props> = ({ stations }) => (
-  <section className="card" style={{ marginTop: 12 }}>
+  <section className="card mt-12">
     <h2>Stations</h2>
     <div className="list">
       {stations.length === 0 ? (
@@ -17,10 +17,10 @@ const StationList: React.FC<Props> = ({ stations }) => (
             <div>
               <b>{s.name}</b>
               <div className="muted">{s.addr}</div>
-              <div style={{ marginTop: 4 }}>
+              <div className="mt-4">
                 Brand: <span className="badge">{s.brand ?? '—'}</span>
               </div>
-              <div style={{ marginTop: 4 }}>
+              <div className="mt-4">
                 Diesel:{' '}
                 <b>
                   {s.dieselPrice != null

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,6 +14,9 @@ input,select{width:100%;padding:10px 12px;border-radius:12px;border:1px solid va
 .badge{font-size:11px;padding:2px 8px;border-radius:999px;background:#1f2937;color:#e5e7eb;border:1px solid var(--border)}
 .small{font-size:12px}
 .muted{color:var(--muted)}
+.mt-4{margin-top:4px}
+.mt-8{margin-top:8px}
+.mt-12{margin-top:12px}
 .ok{background:#0b3320;border:1px solid #22c55e;color:#dcfce7;padding:8px;border-radius:10px}
 .error{background:#2b1515;border:1px solid #7f1d1d;color:#fecaca;padding:8px;border-radius:10px}
 .kvs{display:grid;grid-template-columns:1fr 1fr;gap:6px}
@@ -21,3 +24,8 @@ input,select{width:100%;padding:10px 12px;border-radius:12px;border:1px solid va
 .loading{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.35);z-index:9999}
 .spinner{width:36px;height:36px;border:4px solid rgba(255,255,255,.3);border-top-color:#3b82f6;border-radius:50%;animation:spin 1s linear infinite}
 @keyframes spin{to{transform:rotate(360deg)}}
+.plan-step{display:flex;gap:8px;align-items:center;padding:10px;border:1px solid var(--border);border-radius:12px}
+.plan-step.stop{background:#0b3320;border-color:#22c55e;color:#dcfce7}
+.plan-step.action{background:#14213a;border-color:#3b82f6;color:#e5e7eb}
+.plan-step .icon{font-size:16px}
+.metric-chart{display:block;margin-top:4px}


### PR DESCRIPTION
## Summary
- Add Chart.js-based metric bars for MPG, range, and total miles
- Color-code plan steps with icons to distinguish stops vs. actions
- Replace repeated inline margins with reusable CSS utility classes

## Testing
- `npm test` *(fails: Invalid package.json)*
- `cd frontend && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b3b9d87ad48331b1118de8e571b785